### PR TITLE
Remove the extra openParenthesis map, since we're only using the keys.

### DIFF
--- a/java/src/main/java/bracketsjava/Brackets.java
+++ b/java/src/main/java/bracketsjava/Brackets.java
@@ -1,19 +1,18 @@
 package bracketsjava;
 
 import java.util.ArrayDeque;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 class Brackets {
-  private static final Map<Character, Character> openParentheses = Map.of(
-          '(', ')',
-          '{', '}',
-          '[', ']'
-  );
+
   private static final Map<Character, Character> closedParentheses = Map.of(
           ')', '(',
           '}', '{',
           ']', '['
   );
+  private static final Set<Character> openParentheses = new HashSet<>(closedParentheses.values());
 
   public static void balancedBrackets(String text) throws BracketsNotBalancedException {
     if (text.isEmpty()) { return; } // short-circuit
@@ -21,7 +20,7 @@ class Brackets {
     String[] chars = text.split("");
     for (int i = 0; i < chars.length; i++) {
       char c = chars[i].charAt(0);
-      if (openParentheses.containsKey(c)) {
+      if (openParentheses.contains(c)) {
         stack.push(c);
       } else if (closedParentheses.containsKey(c)) {
         Character open = closedParentheses.get(c);

--- a/kotlin/src/main/kotlin/bracketskt/brackets.kt
+++ b/kotlin/src/main/kotlin/bracketskt/brackets.kt
@@ -2,16 +2,13 @@ package bracketskt
 
 import kotlin.collections.ArrayDeque
 
-var openParentheses = mapOf(
-  '(' to ')',
-  '{' to '}',
-  '[' to ']',
-)
-var closedParentheses = mapOf(
+
+val closedParentheses = mapOf(
   ')' to '(',
   '}' to '{',
   ']' to '[',
 )
+val openParentheses = closedParentheses.values.toSet()
 
 @Throws()
 public fun balancedBrackets(text: String) {
@@ -19,11 +16,11 @@ public fun balancedBrackets(text: String) {
 
   val stack = ArrayDeque<Char>()
   for ((i, c) in text.withIndex()) {
-    when {
-      c in openParentheses -> {
+    when (c) {
+      in openParentheses -> {
         stack.push(c)
       }
-      c in closedParentheses -> {
+      in closedParentheses -> {
         val open = closedParentheses[c]
         val last = stack.removeLastOrNull() ?:
           throw BracketsNotBalancedException("closing bracket $c with no opening bracket at char ${i+1}")

--- a/rust/bracketslib/src/lib.rs
+++ b/rust/bracketslib/src/lib.rs
@@ -1,20 +1,16 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 pub fn balanced_brackets(text: &str) -> Result<(), String> {
-    let opening_brackets = HashMap::from([
-        ('(', ')'),
-        ('[', ']'),
-        ('{', '}'),
-    ]);
     let closing_brackets = HashMap::from([
         (')', '('),
         (']', '['),
         ('}', '{'),
     ]);
+    let opening_brackets: HashSet<char> = closing_brackets.values().cloned().collect();
     let char_vec: Vec<char> = text.chars().collect();
     let mut stack: Vec<char> = vec![];
     for (i, c) in char_vec.iter().enumerate() {
-        if opening_brackets.contains_key(c) {
+        if opening_brackets.contains(c) {
             stack.push(*c)
         } else if closing_brackets.contains_key(c) {
             match stack.pop() {


### PR DESCRIPTION
Remove the extra openParenthesis map, since we're only using the keys, and just create it from the values of the closedParenthesis map. Except in go, which doesn't have a set... because of course it doesn't.